### PR TITLE
meson: Mark assembly .obj as SEH safe on Windows/x86

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -74,6 +74,7 @@ endforeach
 # Default values
 c_sources = ['ffi.c']
 asm_sources = ['sysv.S']
+masm_args = []
 targetdir = ''
 have_long_double = ''
 have_long_double_variant = false
@@ -136,6 +137,7 @@ elif (host_cpu_family == 'x86' and host_system in ['cygwin', 'windows', 'os2', '
     target = 'X86_WIN32'
     if is_msvc_like
       asm_sources = ['sysv_intel.S']
+      masm_args += '/safeseh'
     endif
   else
     target = 'X86_WIN64'

--- a/src/meson.build
+++ b/src/meson.build
@@ -56,6 +56,7 @@ endif
 
 ffi_lib = library('ffi', ffi_c_sources, ffi_asm_sources,
   c_args : ['-DTARGET=' + target, '-DFFI_BUILDING_DLL', public_c_args],
+  masm_args : masm_args,
   include_directories : ffiinc,
   link_args: ffi_link_args,
   link_depends: ffi_map_file,


### PR DESCRIPTION
To fix linking in downstream projects when built as a static library / locally when built as a shared library.